### PR TITLE
Fix comment for URL cleaning

### DIFF
--- a/NLP project.ipynb
+++ b/NLP project.ipynb
@@ -1241,7 +1241,7 @@
     "def clean_text(text):\n",
     "  text = text.lower()\n",
     "  text = re.sub('[^a-z]',' ',text)\n",
-    "  text = re.sub('http\\S+',' ',text,flags=re.MULTILINE)# multiline removes the http in multiple lines\n",
+    "  text = re.sub('http\\S+',' ',text,flags=re.MULTILINE)# remove HTTP links\n",
     "  text = re.sub('\\.+',' ',text)\n",
     "  word_token = word_tokenize(text)\n",
     "  text = [words for words in word_token if words not in stops]\n",


### PR DESCRIPTION
## Summary
- update comment in `clean_text` function to clearly describe removal of HTTP links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68403925ccd8832b9bf0e276dc003b3c